### PR TITLE
Implement `get_block_locations` for MapR, and fix a couple of other minor issues

### DIFF
--- a/hdfs3/core.py
+++ b/hdfs3/core.py
@@ -526,8 +526,7 @@ class HDFileSystem(object):
 
     def tail(self, path, size=1024):
         """ Return last bytes of file """
-        # todo: This logic doesn't work for mapr
-        length = self.du(path)[ensure_trailing_slash(path)]
+        length = self.info(path)['size']
         if size > length:
             return self.cat(path)
         with self.open(path, 'rb') as f:

--- a/hdfs3/core.py
+++ b/hdfs3/core.py
@@ -382,7 +382,8 @@ class HDFileSystem(object):
         num = ctypes.c_int(0)
         fi = _lib.hdfsListDirectory(self._handle, ensure_bytes(path), ctypes.byref(num))
         out = [ensure_string(info_to_dict(fi[i])) for i in range(num.value)]
-        _lib.hdfsFreeFileInfo(fi, num.value)
+        # If the directory is empty, then ``fi`` does not need to be freed
+        _lib.hdfsFreeFileInfo(fi, num.value) if num.value > 0 else None
         if detail:
             return out
         else:

--- a/hdfs3/core.py
+++ b/hdfs3/core.py
@@ -153,6 +153,7 @@ class HDFileSystem(object):
         self.host = host
         self.port = port
         self.user = user
+        self._handle = None
 
         if ticket_cache and token:
             m = "It is not possible to use ticket_cache and token in same time"
@@ -161,7 +162,6 @@ class HDFileSystem(object):
         self.ticket_cache = ticket_cache
         self.token = token
         self.pars = pars or {}
-        self._handle = None
         if connect:
             self.connect()
 

--- a/hdfs3/core.py
+++ b/hdfs3/core.py
@@ -779,10 +779,14 @@ class HDFile(object):
 
     def flush(self):
         """ Send buffer to the data-node; actual write to disc may happen later """
-        _lib.hdfsFlush(self._fs, self._handle)
+        if 'w' in self.mode:
+            _lib.hdfsFlush(self._fs, self._handle)
 
     def close(self):
         """ Flush and close file, ensuring the data is readable """
+        # Prevent multiple attempts to close the file, which will cause libhdfs to throw errors
+        if self.mode == 'closed':
+            return None
         self.flush()
         _lib.hdfsCloseFile(self._fs, self._handle)
         self._handle = None  # _libhdfs releases memory

--- a/hdfs3/lib.py
+++ b/hdfs3/lib.py
@@ -78,6 +78,25 @@ class hdfsFS(ct.Structure):
 # param numOfBlock Output the number of elements in the returned array
 # return An array of BlockLocation struct."""
 
+hdfsGetHosts = _lib.hdfsGetHosts
+hdfsGetHosts.argtypes = [ct.POINTER(hdfsFS), ct.c_char_p, tOffset, tOffset]
+hdfsGetHosts.restype = ct.POINTER(ct.POINTER(ct.c_char_p))
+hdfsGetHosts.__doc__ = """Gets hostnames where a particular block, as determined by the offset and block size, is stored. Due to replication, a single block could be present on multiple hosts.
+
+This function can be useful for understanding the performance implications of file access, and to validate or verify changes to the replication factor.
+
+param fs The handle of the filesystem where the file is located. Obtain this handle with one of the ``hdfsConnect()`` APIs.
+param path The path of the file
+param start The start of the block
+param length The length of the block
+return If successful, returns a dynamically-allocated two-dimensional array of hostnames. The last element in the array is NULL. Returns NULL on error."""
+
+hdfsFreeHosts = _lib.hdfsFreeHosts
+hdfsFreeHosts.argtypes = [ct.POINTER(ct.POINTER(ct.c_char_p))]
+hdfsFreeHosts.restype = None
+hdfsFreeHosts.__doc__ = """Frees an array that was returned by ``hdfsGetHosts()``.
+
+param blockHosts The two-dimensional array that was returned by ``hdfsGetHosts()``."""
 
 # hdfsGetLastError = _lib.hdfsGetLastError
 # hdfsGetLastError.argtypes = []

--- a/hdfs3/tests/test_hdfs3.py
+++ b/hdfs3/tests/test_hdfs3.py
@@ -673,14 +673,13 @@ def test_du(hdfs):
     assert hdfs.du('/tmp/test/', total=True) == {'/tmp/test/': 3 + 4}
 
 
-# TODO: not implementd in mapr
-# def test_get_block_locations(hdfs):
-#     with hdfs.open(a, 'wb') as f:
-#         f.write(b'123')
-#
-#     locs = hdfs.get_block_locations(a)
-#     assert len(locs) == 1
-#     assert locs[0]['length'] == 3
+def test_get_block_locations(hdfs):
+    with hdfs.open(a, 'wb') as f:
+        f.write(b'123')
+
+    locs = hdfs.get_block_locations(a)
+    assert len(locs) == 1
+    assert locs[0]['length'] == 3
 
 
 # TODO: ls in mapr fails for files

--- a/hdfs3/tests/test_hdfs3.py
+++ b/hdfs3/tests/test_hdfs3.py
@@ -28,6 +28,8 @@ def hdfs():
     try:
         yield hdfs
     finally:
+        # The consumer of the test fixture may have disconnected ``hdfs`` already
+        hdfs = HDFileSystem(host='default', port=0)
         if hdfs.exists('/tmp/test'):
             hdfs.rm('/tmp/test')
         hdfs.disconnect()
@@ -653,13 +655,12 @@ def test_get(hdfs):
 
 def test_open_errors(hdfs):
     hdfs.touch(a)
-    # with pytest.raises(ValueError):
-    #     hdfs.open(a, 'rb', block_size=1000)
+    with pytest.raises(ValueError):
+        hdfs.open(a, 'rb', block_size=1000)
 
-    # TODO Why does this cause a segmentation fault?
-    # hdfs.disconnect()
-    # with pytest.raises(IOError):
-    #     hdfs.open(a, 'wb')
+    hdfs.disconnect()
+    with pytest.raises(IOError):
+        hdfs.open(a, 'wb')
 
 
 def test_du(hdfs):

--- a/hdfs3/tests/test_hdfs3.py
+++ b/hdfs3/tests/test_hdfs3.py
@@ -675,15 +675,13 @@ def test_get_block_locations(hdfs):
     assert locs[0]['length'] == 3
 
 
-# TODO: ls in mapr fails for files
-# def test_chmod(hdfs):
-#     hdfs.touch(a)
-#     assert hdfs.ls(a)[0]['permissions'] == 0o777
-#     hdfs.chmod(a, 0o500)
-#     assert hdfs.ls(a)[0]['permissions'] == 0o500
-#     hdfs.chmod(a, 0o100)
-#     with pytest.raises(IOError):
-#         hdfs.open(a, 'ab')
+def test_chmod(hdfs):
+    hdfs.touch(a)
+    hdfs.chmod(a, 0o500)
+    assert hdfs.ls(a)[0]['permissions'] == 0o500
+    hdfs.chmod(a, 0o100)
+    with pytest.raises(IOError):
+        hdfs.open(a, 'ab')
 
 
 @pytest.mark.xfail


### PR DESCRIPTION
- `ls` on empty directories doesn't throw an error
- `tail` works
- repeatedly closing an `HDFile` doesn't throw an error
- `get_block_locations` works